### PR TITLE
Use opendata-stuttgart feinstub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ ADD . /src/
 # Upgrade pip and setuptools
 RUN pip install -q -U pip setuptools
 
-# Install feinstaub from sensors.AFRICA-AQ-api
-RUN pip install -q git+https://github.com/CodeForAfricaLabs/sensors.AFRICA-AQ-api
+# Install feinstaub from opendata-stuttgart
+RUN pip install -q git+https://github.com/opendata-stuttgart/feinstaub-api
 
 # Install sensors.AFRICA-api and its dependencies
 RUN pip install -q -U .


### PR DESCRIPTION
## Description

This change is to start using opendata-stuttgart feinstub instead of sensors.AFRICA AQ feinstaub.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation